### PR TITLE
Add password hashing support

### DIFF
--- a/source/Crypto-Nacl-Tests/NaclTests.class.st
+++ b/source/Crypto-Nacl-Tests/NaclTests.class.st
@@ -84,6 +84,7 @@ NaclTests >> testHashStringSHA512 [
 
 { #category : #tests }
 NaclTests >> testPwHashString [
+	"libsodium does not provide the same hash for the same password."
 	| ops mem a b |
 	ops := Nacl pwHashOpslimitInteractive.
 	mem := Nacl pwHashMemlimitInteractive.
@@ -103,6 +104,7 @@ NaclTests >> testPwHashVerify [
 
 { #category : #tests }
 NaclTests >> testPwNeedsRehash [
+	"Rehash is required whenever requirements change."
 	| ops mem hashString |
 	ops := Nacl pwHashOpslimitInteractive.
 	mem := Nacl pwHashMemlimitInteractive.

--- a/source/Crypto-Nacl-Tests/NaclTests.class.st
+++ b/source/Crypto-Nacl-Tests/NaclTests.class.st
@@ -87,8 +87,8 @@ NaclTests >> testPwHashString [
 	| ops mem a b |
 	ops := Nacl pwHashOpslimitInteractive.
 	mem := Nacl pwHashMemlimitInteractive.
-	a := Nacl pwHashUtf8StringPadded: 'test' opslimit: ops memlimit: mem.
-	b := Nacl pwHashUtf8StringPadded: 'test' opslimit: ops memlimit: mem.
+	a := Nacl pwHashUtf8StringClean: 'test' opslimit: ops memlimit: mem.
+	b := Nacl pwHashUtf8StringClean: 'test' opslimit: ops memlimit: mem.
 	self assert: a ~= b
 ]
 
@@ -97,7 +97,7 @@ NaclTests >> testPwHashVerify [
 	| ops mem hashString |
 	ops := Nacl pwHashOpslimitInteractive.
 	mem := Nacl pwHashMemlimitInteractive.
-	hashString := Nacl pwHashUtf8StringPadded: 'test' opslimit: ops memlimit: mem.
+	hashString := Nacl pwHashUtf8StringClean: 'test' opslimit: ops memlimit: mem.
 	self assert: (Nacl pwHashStringIsVerified: hashString password: 'test') equals: true.
 ]
 
@@ -106,7 +106,7 @@ NaclTests >> testPwNeedsRehash [
 	| ops mem hashString |
 	ops := Nacl pwHashOpslimitInteractive.
 	mem := Nacl pwHashMemlimitInteractive.
-	hashString := Nacl pwHashUtf8StringPadded: 'test' opslimit: ops memlimit: mem.
+	hashString := Nacl pwHashUtf8StringClean: 'test' opslimit: ops memlimit: mem.
 	self assert: ( Nacl pwHashStringNeedsRehash: hashString  opslimit: ops memlimit: mem ) equals: false.
 	self assert: ( Nacl pwHashStringNeedsRehash: hashString  opslimit: Nacl pwHashOpslimitSensitive memlimit: mem ) equals: true.
 ]

--- a/source/Crypto-Nacl-Tests/NaclTests.class.st
+++ b/source/Crypto-Nacl-Tests/NaclTests.class.st
@@ -98,7 +98,7 @@ NaclTests >> testPwHashVerify [
 	ops := Nacl pwHashOpslimitInteractive.
 	mem := Nacl pwHashMemlimitInteractive.
 	hashString := Nacl pwHashUtf8StringPadded: 'test' opslimit: ops memlimit: mem.
-	self assert: (Nacl pwHashStringVerified: hashString password: 'test') equals: true.
+	self assert: (Nacl pwHashStringIsVerified: hashString password: 'test') equals: true.
 ]
 
 { #category : #tests }
@@ -107,8 +107,8 @@ NaclTests >> testPwNeedsRehash [
 	ops := Nacl pwHashOpslimitInteractive.
 	mem := Nacl pwHashMemlimitInteractive.
 	hashString := Nacl pwHashUtf8StringPadded: 'test' opslimit: ops memlimit: mem.
-	self assert: ( Nacl pwHashStrNeedsRehash: hashString  opslimit: ops memlimit: mem ) equals: false.
-	self assert: ( Nacl pwHashStrNeedsRehash: hashString  opslimit: Nacl pwHashOpslimitSensitive memlimit: mem ) equals: true.
+	self assert: ( Nacl pwHashStringNeedsRehash: hashString  opslimit: ops memlimit: mem ) equals: false.
+	self assert: ( Nacl pwHashStringNeedsRehash: hashString  opslimit: Nacl pwHashOpslimitSensitive memlimit: mem ) equals: true.
 ]
 
 { #category : #test }

--- a/source/Crypto-Nacl-Tests/NaclTests.class.st
+++ b/source/Crypto-Nacl-Tests/NaclTests.class.st
@@ -82,6 +82,35 @@ NaclTests >> testHashStringSHA512 [
 	self assert: (Nacl hashStringSHA512: 'The quick brown fox jumps over the lazy dog.') hex equals: '91ea1245f20d46ae9a037a989f54f1f790f0a47607eeb8a14d12890cea77a1bbc6c7ed9cf205e67b7f2b8fd4c7dfd3a7a8617e45f3c463d481c7e586c39ac1ed'.
 ]
 
+{ #category : #tests }
+NaclTests >> testPwHashString [
+	| ops mem a b |
+	ops := Nacl pwHashOpslimitInteractive.
+	mem := Nacl pwHashMemlimitInteractive.
+	a := Nacl pwHashUtf8StringPadded: 'test' opslimit: ops memlimit: mem.
+	b := Nacl pwHashUtf8StringPadded: 'test' opslimit: ops memlimit: mem.
+	self assert: a ~= b
+]
+
+{ #category : #tests }
+NaclTests >> testPwHashVerify [
+	| ops mem hashString |
+	ops := Nacl pwHashOpslimitInteractive.
+	mem := Nacl pwHashMemlimitInteractive.
+	hashString := Nacl pwHashUtf8StringPadded: 'test' opslimit: ops memlimit: mem.
+	self assert: (Nacl pwHashStringVerified: hashString password: 'test') equals: true.
+]
+
+{ #category : #tests }
+NaclTests >> testPwNeedsRehash [
+	| ops mem hashString |
+	ops := Nacl pwHashOpslimitInteractive.
+	mem := Nacl pwHashMemlimitInteractive.
+	hashString := Nacl pwHashUtf8StringPadded: 'test' opslimit: ops memlimit: mem.
+	self assert: ( Nacl pwHashStrNeedsRehash: hashString  opslimit: ops memlimit: mem ) equals: false.
+	self assert: ( Nacl pwHashStrNeedsRehash: hashString  opslimit: Nacl pwHashOpslimitSensitive memlimit: mem ) equals: true.
+]
+
 { #category : #test }
 NaclTests >> testRandomBytes [
 	self assert: (Nacl randomBytes: 1) size equals: 1.

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -299,9 +299,12 @@ Nacl class >> isBigEndian [
 
 { #category : #'pwhashing/private' }
 Nacl class >> pwCheckForRehash: str opslimit: ops memlimit: mem [ 
-	^ self ffiCall:
+|result|
+self assertInitialized .
+	result:= self ffiCall:
 			#(int crypto_pwhash_str_needs_rehash(char *str , ulonglong ops , size_t mem))
 		library: Nacl.
+ ^ result
 ]
 
 { #category : #'pwhashing/private' }
@@ -367,9 +370,12 @@ Nacl class >> pwHashStrBytes [
 
 { #category : #pwhashing }
 Nacl class >> pwHashStrNeedsRehash: hashString opslimit: ops memlimit: mem [
-	| str result |
-	str := hashString asUtf8ByteArray.
-	result := self pwCheckForRehash: str opslimit: ops memlimit: mem.
+	| result |
+	self assertInitialized.
+	result := self
+		pwCheckForRehash: hashString
+		opslimit: ops
+		memlimit: mem.
 	^ result ~= 0
 ]
 
@@ -381,6 +387,7 @@ Nacl class >> pwHashString: aString opslimit: ops memlimit: mem [
 { #category : #pwhashing }
 Nacl class >> pwHashStringVerified: hashString password: pwd [
 	| hash pwdlen result |
+	self assertInitialized.
 	hash := hashString asUtf8ByteArray.
 	pwdlen := pwd size.
 	result := self pwHashVerify: hash in: pwd inLen: pwdlen.

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -55,7 +55,7 @@ Nacl class >> apiCryptoHashSha512Output: out input: in inputLength: inlen [
 		module: Nacl
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #api }
 Nacl class >> apiCryptoPwHashOutput: out input: in inputLength: inlen opsLimit: ops memLimit: mem [
 	self assertInitialized.
 	^ self
@@ -297,73 +297,105 @@ Nacl class >> isBigEndian [
 	^ (Smalltalk at: #EndianDetector) isBigEndian
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'pwhashing/private' }
 Nacl class >> pwCheckForRehash: str opslimit: ops memlimit: mem [ 
 	^ self ffiCall:
 			#(int crypto_pwhash_str_needs_rehash(char *str , ulonglong ops , size_t mem))
 		library: Nacl.
 ]
 
-{ #category : #'as yet unclassified' }
-Nacl class >> pwHashDefault: password [ 
-| result ops mem|
-	ops := self pwHashOpslimitInteractive.
-	mem := self pwHashMemlimitInteractive.
-result := ByteArray new: self pwHashStrBytes.
-self checkError: 'crypto hash failed' apiResult: (self apiCryptoPwHashOutput: result input: password inputLength: password size opsLimit: ops memLimit: mem).
-^ result 
+{ #category : #'pwhashing/private' }
+Nacl class >> pwHash: password opslimit: ops memlimit: mem [
+	| result |
+	result := ByteArray new: self pwHashStrBytes.
+	self
+		checkError: 'crypto hash failed'
+		apiResult:
+			(self
+				apiCryptoPwHashOutput: result
+				input: password
+				inputLength: password size
+				opsLimit: ops
+				memLimit: mem).
+	^ result
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'pwhashing/limits' }
 Nacl class >> pwHashMemlimitInteractive [
 	^ self ffiCall: #(size_t crypto_pwhash_memlimit_interactive()) library: Nacl 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'pwhashing/limits' }
+Nacl class >> pwHashMemlimitMax [
+	^ self ffiCall: #(size_t crypto_pwhash_memlimit_max()) library: Nacl 
+]
+
+{ #category : #'pwhashing/limits' }
+Nacl class >> pwHashMemlimitMin [
+	^ self ffiCall: #(size_t crypto_pwhash_memlimit_min()) library: Nacl 
+]
+
+{ #category : #'pwhashing/limits' }
+Nacl class >> pwHashMemlimitSensitive [
+	^ self ffiCall: #(size_t crypto_pwhash_memlimit_sensitive()) library: Nacl 
+]
+
+{ #category : #'pwhashing/limits' }
 Nacl class >> pwHashOpslimitInteractive [
 	^ self ffiCall: #( size_t crypto_pwhash_opslimit_interactive() ) library: Nacl
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'pwhashing/limits' }
+Nacl class >> pwHashOpslimitMax [
+	^ self ffiCall: #( size_t crypto_pwhash_opslimit_max() ) library: Nacl
+]
+
+{ #category : #'pwhashing/limits' }
+Nacl class >> pwHashOpslimitMin [
+	^ self ffiCall: #( size_t crypto_pwhash_opslimit_min() ) library: Nacl
+]
+
+{ #category : #'pwhashing/limits' }
+Nacl class >> pwHashOpslimitSensitive [
+	^ self ffiCall: #( size_t crypto_pwhash_opslimit_sensitive() ) library: Nacl
+]
+
+{ #category : #'pwhashing/private' }
 Nacl class >> pwHashStrBytes [
 	^ self ffiCall: #( size_t crypto_pwhash_strbytes() ) library: Nacl 
 ]
 
-{ #category : #'as yet unclassified' }
-Nacl class >> pwHashStrNeedsRehash: hashString [
-	| opslimit memlimit str result |
+{ #category : #pwhashing }
+Nacl class >> pwHashStrNeedsRehash: hashString opslimit: ops memlimit: mem [
+	| str result |
 	str := hashString asUtf8ByteArray.
-	opslimit := self pwHashOpslimitInteractive.
-	memlimit := self pwHashMemlimitInteractive.
-	result := self pwCheckForRehash: str opslimit: opslimit memlimit: memlimit.
+	result := self pwCheckForRehash: str opslimit: ops memlimit: mem.
 	^ result ~= 0
 ]
 
-{ #category : #'as yet unclassified' }
-Nacl class >> pwHashString: aString [
-	^ self pwHashDefault: aString asUtf8ByteArray 
+{ #category : #pwhashing }
+Nacl class >> pwHashString: aString opslimit: ops memlimit: mem [
+	^ self pwHash: aString asUtf8ByteArray opslimit: ops memlimit: mem
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #pwhashing }
 Nacl class >> pwHashStringVerified: hashString password: pwd [
 	| hash pwdlen result |
-	hash	:= hashString asUtf8ByteArray.
-	pwdlen :=pwd size.
+	hash := hashString asUtf8ByteArray.
+	pwdlen := pwd size.
 	result := self pwHashVerify: hash in: pwd inLen: pwdlen.
 	^ result = 0
-
-
-
 ]
 
-{ #category : #'as yet unclassified' }
-Nacl class >> pwHashUtf8StringPadded: password [
+{ #category : #pwhashing }
+Nacl class >> pwHashUtf8StringPadded: password opslimit: ops memlimit: mem [
 	| hash |
-	hash := (self pwHashString: password) select: [ :each | each ~= 0 ].
+	hash := (self pwHashString: password opslimit: ops memlimit: mem)
+		select: [ :each | each ~= 0 ].
 	^ hash asUtf8String
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'pwhashing/private' }
 Nacl class >> pwHashVerify: str in: pwd inLen: pwdlen [
 	^ self ffiCall: #( int crypto_pwhash_str_verify( char *str , char *pwd, ulonglong pwdlen)) library: Nacl
 ]

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -327,6 +327,13 @@ Nacl class >> pwHashString: aString [
 	^ self pwHashDefault: aString asUtf8ByteArray 
 ]
 
+{ #category : #'as yet unclassified' }
+Nacl class >> pwHashUtf8StringPadded: password [
+	| hash |
+	hash := (self pwHashString: password) select: [ :each | each ~= 0 ].
+	^ hash asUtf8String
+]
+
 { #category : #api }
 Nacl class >> randomBytes: n [
 	| result |

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -319,14 +319,13 @@ self checkError: 'crypto hash failed' apiResult: (self apiPwHashOutput: result i
 
 { #category : #'as yet unclassified' }
 Nacl class >> pwHashMemlimitInteractive [
-	"^ self ffiCall: #(size_t crypto_pwhash_memlimit_interactive()) library: Nacl "
-	^ 65536
+	^ self ffiCall: #(size_t crypto_pwhash_memlimit_interactive()) library: Nacl 
 ]
 
 { #category : #'as yet unclassified' }
 Nacl class >> pwHashOpslimitInteractive [
 	"^ self ffiCall: #( size_t crypto_pwhash_memlimit_interactive() ) library: Nacl"
-	^ 1
+	^ 2
 ]
 
 { #category : #'as yet unclassified' }

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -57,6 +57,7 @@ Nacl class >> apiCryptoHashSha512Output: out input: in inputLength: inlen [
 
 { #category : #api }
 Nacl class >> apiCryptoPwHashOutput: out input: in inputLength: inlen opsLimit: ops memLimit: mem [
+	"Low level api. Use pwHashString or pwHashUtf8StringClean"
 	self assertInitialized.
 	^ self
 		ffiCall: #( int crypto_pwhash_str(uchar *out , uchar *in , ulonglong inlen , ulonglong ops , size_t mem)) library: Nacl
@@ -366,6 +367,8 @@ Nacl class >> pwHashOpslimitSensitive [
 
 { #category : #'password hashing/private' }
 Nacl class >> pwHashStrBytes [
+	"The maximum number of bytes in password hash. Provided by libsodium and can change.
+	The actual hash size can be smaller."
 	^ self ffiCall: #( size_t crypto_pwhash_strbytes() ) library: Nacl 
 ]
 

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -297,17 +297,18 @@ Nacl class >> isBigEndian [
 	^ (Smalltalk at: #EndianDetector) isBigEndian
 ]
 
-{ #category : #'pwhashing/private' }
-Nacl class >> pwCheckForRehash: str opslimit: ops memlimit: mem [ 
-|result|
-self assertInitialized .
-	result:= self ffiCall:
-			#(int crypto_pwhash_str_needs_rehash(char *str , ulonglong ops , size_t mem))
+{ #category : #'password hashing/private' }
+Nacl class >> pwCheckForRehash: str opslimit: ops memlimit: mem [
+	| result |
+	self assertInitialized.
+	result := self
+		ffiCall:
+			#(int crypto_pwhash_str_needs_rehash #(char * str , ulonglong ops , size_t mem))
 		library: Nacl.
- ^ result
+	^ result
 ]
 
-{ #category : #'pwhashing/private' }
+{ #category : #'password hashing/private' }
 Nacl class >> pwHash: password opslimit: ops memlimit: mem [
 	| result |
 	result := ByteArray new: self pwHashStrBytes.
@@ -323,52 +324,52 @@ Nacl class >> pwHash: password opslimit: ops memlimit: mem [
 	^ result
 ]
 
-{ #category : #'pwhashing/limits' }
+{ #category : #'password hashing/limits' }
 Nacl class >> pwHashMemlimitInteractive [
 	^ self ffiCall: #(size_t crypto_pwhash_memlimit_interactive()) library: Nacl 
 ]
 
-{ #category : #'pwhashing/limits' }
+{ #category : #'password hashing/limits' }
 Nacl class >> pwHashMemlimitMax [
 	^ self ffiCall: #(size_t crypto_pwhash_memlimit_max()) library: Nacl 
 ]
 
-{ #category : #'pwhashing/limits' }
+{ #category : #'password hashing/limits' }
 Nacl class >> pwHashMemlimitMin [
 	^ self ffiCall: #(size_t crypto_pwhash_memlimit_min()) library: Nacl 
 ]
 
-{ #category : #'pwhashing/limits' }
+{ #category : #'password hashing/limits' }
 Nacl class >> pwHashMemlimitSensitive [
 	^ self ffiCall: #(size_t crypto_pwhash_memlimit_sensitive()) library: Nacl 
 ]
 
-{ #category : #'pwhashing/limits' }
+{ #category : #'password hashing/limits' }
 Nacl class >> pwHashOpslimitInteractive [
 	^ self ffiCall: #( size_t crypto_pwhash_opslimit_interactive() ) library: Nacl
 ]
 
-{ #category : #'pwhashing/limits' }
+{ #category : #'password hashing/limits' }
 Nacl class >> pwHashOpslimitMax [
 	^ self ffiCall: #( size_t crypto_pwhash_opslimit_max() ) library: Nacl
 ]
 
-{ #category : #'pwhashing/limits' }
+{ #category : #'password hashing/limits' }
 Nacl class >> pwHashOpslimitMin [
 	^ self ffiCall: #( size_t crypto_pwhash_opslimit_min() ) library: Nacl
 ]
 
-{ #category : #'pwhashing/limits' }
+{ #category : #'password hashing/limits' }
 Nacl class >> pwHashOpslimitSensitive [
 	^ self ffiCall: #( size_t crypto_pwhash_opslimit_sensitive() ) library: Nacl
 ]
 
-{ #category : #'pwhashing/private' }
+{ #category : #'password hashing/private' }
 Nacl class >> pwHashStrBytes [
 	^ self ffiCall: #( size_t crypto_pwhash_strbytes() ) library: Nacl 
 ]
 
-{ #category : #pwhashing }
+{ #category : #'password hashing' }
 Nacl class >> pwHashStrNeedsRehash: hashString opslimit: ops memlimit: mem [
 	| result |
 	self assertInitialized.
@@ -379,12 +380,12 @@ Nacl class >> pwHashStrNeedsRehash: hashString opslimit: ops memlimit: mem [
 	^ result ~= 0
 ]
 
-{ #category : #pwhashing }
+{ #category : #'password hashing' }
 Nacl class >> pwHashString: aString opslimit: ops memlimit: mem [
 	^ self pwHash: (aString asUtf8ByteArray) opslimit: ops memlimit: mem
 ]
 
-{ #category : #pwhashing }
+{ #category : #'password hashing' }
 Nacl class >> pwHashStringVerified: hashString password: pwd [
 	| hash pwdlen result |
 	self assertInitialized.
@@ -394,7 +395,7 @@ Nacl class >> pwHashStringVerified: hashString password: pwd [
 	^ result = 0
 ]
 
-{ #category : #pwhashing }
+{ #category : #'password hashing' }
 Nacl class >> pwHashUtf8StringPadded: password opslimit: ops memlimit: mem [
 	| hash |
 	hash := (self pwHashString: password opslimit: ops memlimit: mem)
@@ -402,7 +403,7 @@ Nacl class >> pwHashUtf8StringPadded: password opslimit: ops memlimit: mem [
 	^ hash asUtf8String
 ]
 
-{ #category : #'pwhashing/private' }
+{ #category : #'password hashing/private' }
 Nacl class >> pwHashVerify: str in: pwd inLen: pwdlen [
 	^ self ffiCall: #( int crypto_pwhash_str_verify( char *str , char *pwd, ulonglong pwdlen)) library: Nacl
 ]

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -324,8 +324,7 @@ Nacl class >> pwHashMemlimitInteractive [
 
 { #category : #'as yet unclassified' }
 Nacl class >> pwHashOpslimitInteractive [
-	"^ self ffiCall: #( size_t crypto_pwhash_memlimit_interactive() ) library: Nacl"
-	^ 2
+	^ self ffiCall: #( size_t crypto_pwhash_opslimit_interactive() ) library: Nacl
 ]
 
 { #category : #'as yet unclassified' }

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -118,6 +118,23 @@ Nacl class >> apiInitialize [
 		module: Nacl
 ]
 
+{ #category : #'as yet unclassified' }
+Nacl class >> apiPwHashOutput: out input: in inputLength: inlen [
+	|ops mem|
+	ops := self pwHashOpslimitInteractive.
+	mem := self pwHashMemlimitInteractive.
+	self assertInitialized.
+	^ self
+		ffiCall: #( int crypto_pwhash_str(uchar *out , uchar *in , ulonglong inlen , ulonglong ops , size_t mem)) library: Nacl
+]
+
+{ #category : #'as yet unclassified' }
+Nacl class >> apiPwHashOutput: out input: in inputLength: inlen opsLimit: ops memLimit: mem [
+	self assertInitialized.
+	^ self
+		ffiCall: #( int crypto_pwhash_str(uchar *out , uchar *in , ulonglong inlen , ulonglong ops , size_t mem)) library: Nacl
+]
+
 { #category : #api }
 Nacl class >> apiRandomBytes: buf length: size [
 	"Fills buf with an unpredictable sequence of size bytes.
@@ -288,6 +305,38 @@ Nacl class >> hashStringSHA512: aString [
 Nacl class >> isBigEndian [
 
 	^ (Smalltalk at: #EndianDetector) isBigEndian
+]
+
+{ #category : #'as yet unclassified' }
+Nacl class >> pwHashDefault: password [ 
+| result ops mem|
+	ops := self pwHashOpslimitInteractive.
+	mem := self pwHashMemlimitInteractive.
+result := ByteArray new: self pwHashStrBytes.
+self checkError: 'crypto hash failed' apiResult: (self apiPwHashOutput: result input: password inputLength: password size opsLimit: ops memLimit: mem).
+^ result 
+]
+
+{ #category : #'as yet unclassified' }
+Nacl class >> pwHashMemlimitInteractive [
+	"^ self ffiCall: #(size_t crypto_pwhash_memlimit_interactive()) library: Nacl "
+	^ 65536
+]
+
+{ #category : #'as yet unclassified' }
+Nacl class >> pwHashOpslimitInteractive [
+	"^ self ffiCall: #( size_t crypto_pwhash_memlimit_interactive() ) library: Nacl"
+	^ 1
+]
+
+{ #category : #'as yet unclassified' }
+Nacl class >> pwHashStrBytes [
+	^ self ffiCall: #( size_t crypto_pwhash_strbytes() ) library: Nacl 
+]
+
+{ #category : #'as yet unclassified' }
+Nacl class >> pwHashString: aString [
+	^ self pwHashDefault: aString asUtf8ByteArray 
 ]
 
 { #category : #api }

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -298,6 +298,13 @@ Nacl class >> isBigEndian [
 ]
 
 { #category : #'as yet unclassified' }
+Nacl class >> pwCheckForRehash: str opslimit: ops memlimit: mem [ 
+	^ self ffiCall:
+			#(int crypto_pwhash_str_needs_rehash(char *str , ulonglong ops , size_t mem))
+		library: Nacl.
+]
+
+{ #category : #'as yet unclassified' }
 Nacl class >> pwHashDefault: password [ 
 | result ops mem|
 	ops := self pwHashOpslimitInteractive.
@@ -320,6 +327,16 @@ Nacl class >> pwHashOpslimitInteractive [
 { #category : #'as yet unclassified' }
 Nacl class >> pwHashStrBytes [
 	^ self ffiCall: #( size_t crypto_pwhash_strbytes() ) library: Nacl 
+]
+
+{ #category : #'as yet unclassified' }
+Nacl class >> pwHashStrNeedsRehash: hashString [
+	| opslimit memlimit str result |
+	str := hashString asUtf8ByteArray.
+	opslimit := self pwHashOpslimitInteractive.
+	memlimit := self pwHashMemlimitInteractive.
+	result := self pwCheckForRehash: str opslimit: opslimit memlimit: memlimit.
+	^ result ~= 0
 ]
 
 { #category : #'as yet unclassified' }
@@ -349,11 +366,6 @@ Nacl class >> pwHashUtf8StringPadded: password [
 { #category : #'as yet unclassified' }
 Nacl class >> pwHashVerify: str in: pwd inLen: pwdlen [
 	^ self ffiCall: #( int crypto_pwhash_str_verify( char *str , char *pwd, ulonglong pwdlen)) library: Nacl
-]
-
-{ #category : #'as yet unclassified' }
-Nacl class >> pwStringHashVerify: str in: pwd inLen: pwdlen [
-	^ self ffiCall: #( int crypto_pwhash_str_verify( char *str , char *pwh, ulonglong pwdlen)) library: Nacl
 ]
 
 { #category : #api }

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -370,7 +370,22 @@ Nacl class >> pwHashStrBytes [
 ]
 
 { #category : #'password hashing' }
-Nacl class >> pwHashStrNeedsRehash: hashString opslimit: ops memlimit: mem [
+Nacl class >> pwHashString: aString opslimit: ops memlimit: mem [
+	^ self pwHash: (aString asUtf8ByteArray) opslimit: ops memlimit: mem
+]
+
+{ #category : #'password hashing' }
+Nacl class >> pwHashStringIsVerified: hashString password: pwd [
+	| hash pwdlen result |
+	self assertInitialized.
+	hash := hashString asUtf8ByteArray.
+	pwdlen := pwd size.
+	result := self pwHashVerify: hash in: pwd inLen: pwdlen.
+	^ result = 0
+]
+
+{ #category : #'password hashing' }
+Nacl class >> pwHashStringNeedsRehash: hashString opslimit: ops memlimit: mem [
 	| result |
 	self assertInitialized.
 	result := self
@@ -378,21 +393,6 @@ Nacl class >> pwHashStrNeedsRehash: hashString opslimit: ops memlimit: mem [
 		opslimit: ops
 		memlimit: mem.
 	^ result ~= 0
-]
-
-{ #category : #'password hashing' }
-Nacl class >> pwHashString: aString opslimit: ops memlimit: mem [
-	^ self pwHash: (aString asUtf8ByteArray) opslimit: ops memlimit: mem
-]
-
-{ #category : #'password hashing' }
-Nacl class >> pwHashStringVerified: hashString password: pwd [
-	| hash pwdlen result |
-	self assertInitialized.
-	hash := hashString asUtf8ByteArray.
-	pwdlen := pwd size.
-	result := self pwHashVerify: hash in: pwd inLen: pwdlen.
-	^ result = 0
 ]
 
 { #category : #'password hashing' }

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -55,6 +55,13 @@ Nacl class >> apiCryptoHashSha512Output: out input: in inputLength: inlen [
 		module: Nacl
 ]
 
+{ #category : #'as yet unclassified' }
+Nacl class >> apiCryptoPwHashOutput: out input: in inputLength: inlen opsLimit: ops memLimit: mem [
+	self assertInitialized.
+	^ self
+		ffiCall: #( int crypto_pwhash_str(uchar *out , uchar *in , ulonglong inlen , ulonglong ops , size_t mem)) library: Nacl
+]
+
 { #category : #api }
 Nacl class >> apiCryptoScalarmultCurve25519BaseTarget: pk source: sk [
 	self assertInitialized.
@@ -116,23 +123,6 @@ Nacl class >> apiInitialize [
 	^ self 
 		ffiCall: #(int sodium_init(void)) 
 		module: Nacl
-]
-
-{ #category : #'as yet unclassified' }
-Nacl class >> apiPwHashOutput: out input: in inputLength: inlen [
-	|ops mem|
-	ops := self pwHashOpslimitInteractive.
-	mem := self pwHashMemlimitInteractive.
-	self assertInitialized.
-	^ self
-		ffiCall: #( int crypto_pwhash_str(uchar *out , uchar *in , ulonglong inlen , ulonglong ops , size_t mem)) library: Nacl
-]
-
-{ #category : #'as yet unclassified' }
-Nacl class >> apiPwHashOutput: out input: in inputLength: inlen opsLimit: ops memLimit: mem [
-	self assertInitialized.
-	^ self
-		ffiCall: #( int crypto_pwhash_str(uchar *out , uchar *in , ulonglong inlen , ulonglong ops , size_t mem)) library: Nacl
 ]
 
 { #category : #api }
@@ -313,7 +303,7 @@ Nacl class >> pwHashDefault: password [
 	ops := self pwHashOpslimitInteractive.
 	mem := self pwHashMemlimitInteractive.
 result := ByteArray new: self pwHashStrBytes.
-self checkError: 'crypto hash failed' apiResult: (self apiPwHashOutput: result input: password inputLength: password size opsLimit: ops memLimit: mem).
+self checkError: 'crypto hash failed' apiResult: (self apiCryptoPwHashOutput: result input: password inputLength: password size opsLimit: ops memLimit: mem).
 ^ result 
 ]
 

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -371,11 +371,17 @@ Nacl class >> pwHashStrBytes [
 
 { #category : #'password hashing' }
 Nacl class >> pwHashString: aString opslimit: ops memlimit: mem [
+	"Password hashing for password storage as per https://doc.libsodium.org/password_hashing/default_phf.
+	Hashes the input string. ops is the maximum amount of computations to perform, and mem is the maximum
+	amount of RAM to use. These are provided by libsodium, see pwHashOpslimit* and pwHashMemlimit* methond.
+	The result is a ByteArray of size crypto_pwhash_STRBYTES. Actual hash can be smaller, so the array is
+	padded with zeroes an the right. To get just the string containing the hash use pwHashUtf8StringClean."
 	^ self pwHash: (aString asUtf8ByteArray) opslimit: ops memlimit: mem
 ]
 
 { #category : #'password hashing' }
 Nacl class >> pwHashStringIsVerified: hashString password: pwd [
+	"Check if the hash hashString (provided by pwHashUtf8StringClean) can be verified against password pwd."
 	| hash pwdlen result |
 	self assertInitialized.
 	hash := hashString asUtf8ByteArray.
@@ -386,6 +392,8 @@ Nacl class >> pwHashStringIsVerified: hashString password: pwd [
 
 { #category : #'password hashing' }
 Nacl class >> pwHashStringNeedsRehash: hashString opslimit: ops memlimit: mem [
+	"Check if the given hashString needs to be rehashed due to changes in recommended values.
+	The method should be provided with the same opslimit and memlimit as the original pwHashString."
 	| result |
 	self assertInitialized.
 	result := self
@@ -396,7 +404,7 @@ Nacl class >> pwHashStringNeedsRehash: hashString opslimit: ops memlimit: mem [
 ]
 
 { #category : #'password hashing' }
-Nacl class >> pwHashUtf8StringPadded: password opslimit: ops memlimit: mem [
+Nacl class >> pwHashUtf8StringClean: password opslimit: ops memlimit: mem [
 	| hash |
 	hash := (self pwHashString: password opslimit: ops memlimit: mem)
 		select: [ :each | each ~= 0 ].

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -328,10 +328,32 @@ Nacl class >> pwHashString: aString [
 ]
 
 { #category : #'as yet unclassified' }
+Nacl class >> pwHashStringVerified: hashString password: pwd [
+	| hash pwdlen result |
+	hash	:= hashString asUtf8ByteArray.
+	pwdlen :=pwd size.
+	result := self pwHashVerify: hash in: pwd inLen: pwdlen.
+	^ result = 0
+
+
+
+]
+
+{ #category : #'as yet unclassified' }
 Nacl class >> pwHashUtf8StringPadded: password [
 	| hash |
 	hash := (self pwHashString: password) select: [ :each | each ~= 0 ].
 	^ hash asUtf8String
+]
+
+{ #category : #'as yet unclassified' }
+Nacl class >> pwHashVerify: str in: pwd inLen: pwdlen [
+	^ self ffiCall: #( int crypto_pwhash_str_verify( char *str , char *pwd, ulonglong pwdlen)) library: Nacl
+]
+
+{ #category : #'as yet unclassified' }
+Nacl class >> pwStringHashVerify: str in: pwd inLen: pwdlen [
+	^ self ffiCall: #( int crypto_pwhash_str_verify( char *str , char *pwh, ulonglong pwdlen)) library: Nacl
 ]
 
 { #category : #api }

--- a/source/Crypto-Nacl/Nacl.class.st
+++ b/source/Crypto-Nacl/Nacl.class.st
@@ -375,7 +375,7 @@ Nacl class >> pwHashStrNeedsRehash: hashString opslimit: ops memlimit: mem [
 
 { #category : #pwhashing }
 Nacl class >> pwHashString: aString opslimit: ops memlimit: mem [
-	^ self pwHash: aString asUtf8ByteArray opslimit: ops memlimit: mem
+	^ self pwHash: (aString asUtf8ByteArray) opslimit: ops memlimit: mem
 ]
 
 { #category : #pwhashing }


### PR DESCRIPTION
### Reference issues/PRs
None.

### What does it implement
There is no password hashing function interface implemented. So I provided a simple interface to libsodium password hashing as described in the docs [here](https://doc.libsodium.org/password_hashing/default_phf). There are no changes to the original implementation, except the added methods. I hope it will be useful not just to me.